### PR TITLE
feat: jsx spread children

### DIFF
--- a/src/js_parser.zig
+++ b/src/js_parser.zig
@@ -14392,14 +14392,19 @@ fn NewParser_(
                         // Use Next() instead of NextJSXElementChild() here since the next token is an expression
                         try p.lexer.next();
 
-                        // The "..." here is ignored (it's used to signal an array type in TypeScript)
-                        if (p.lexer.token == .t_dot_dot_dot and is_typescript_enabled) {
+                        const is_spread = p.lexer.token == .t_dot_dot_dot;
+                        if (is_spread) {
+                            // p.markSyntaxFeature()
                             try p.lexer.next();
                         }
 
                         // The expression is optional, and may be absent
                         if (p.lexer.token != .t_close_brace) {
-                            try children.append(try p.parseExpr(.lowest));
+                            var item = try p.parseExpr(.lowest);
+                            if (is_spread) {
+                                item = p.newExpr(E.Spread{ .value = item }, loc);
+                            }
+                            try children.append(item);
                         }
 
                         // Use ExpectJSXElementChild() so we parse child strings
@@ -15087,28 +15092,23 @@ fn NewParser_(
                                         props = props.items[0].value.?.data.e_object.properties.list();
                                     }
 
-                                    // Babel defines static jsx as children.len > 1
-                                    const is_static_jsx = e_.children.len > 1;
+                                    // Typescript defines static jsx as children.len > 1 or single spread
+                                    // https://github.com/microsoft/TypeScript/blob/d4fbc9b57d9aa7d02faac9b1e9bb7b37c687f6e9/src/compiler/transformers/jsx.ts#L340
+                                    const is_static_jsx = e_.children.len > 1 or (e_.children.len == 1 and e_.children.ptr[0].data == .e_spread);
 
-                                    // if (p.options.jsx.development) {
-
-                                    switch (e_.children.len) {
-                                        0 => {},
-                                        1 => {
-                                            props.append(allocator, G.Property{
-                                                .key = children_key,
-                                                .value = e_.children.ptr[0],
-                                            }) catch unreachable;
-                                        },
-                                        else => {
-                                            props.append(allocator, G.Property{
-                                                .key = children_key,
-                                                .value = p.newExpr(E.Array{
-                                                    .items = e_.children,
-                                                    .is_single_line = e_.children.len < 2,
-                                                }, e_.close_tag_loc),
-                                            }) catch unreachable;
-                                        },
+                                    if (is_static_jsx) {
+                                        props.append(allocator, G.Property{
+                                            .key = children_key,
+                                            .value = p.newExpr(E.Array{
+                                                .items = e_.children,
+                                                .is_single_line = e_.children.len < 2,
+                                            }, e_.close_tag_loc),
+                                        }) catch unreachable;
+                                    } else if (e_.children.len == 1) {
+                                        props.append(allocator, G.Property{
+                                            .key = children_key,
+                                            .value = e_.children.ptr[0],
+                                        }) catch unreachable;
                                     }
                                     // --- These must be done in all cases --
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
